### PR TITLE
ネストしたディレクトリを作成してもエラーが出ないようにする

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ task :default do
   file = NippouGen::Generator.today_report_file
   dir = NippouGen::Generator.today_report_dir
 
-  Dir.mkdir(dir) unless Dir.exist?(dir)
+  FileUtils::mkdir_p(dir) unless Dir.exist?(dir)
 
   post = NippouGen::Esa.today_report
 


### PR DESCRIPTION
# エラー内容

https://startuptechnologyteam.slack.com/archives/times_takita/p1489382077428813

# 再現方法

1. nippou_gem ディレクトリの ` ./reports/ ` を削除
2. bin/nippou

# 参考
[stackoverflow](http://stackoverflow.com/questions/19280341/create-directory-if-it-doesnt-exist-with-ruby)